### PR TITLE
Fix factory class method on IPAddr6 to return the object

### DIFF
--- a/pox/lib/addresses.py
+++ b/pox/lib/addresses.py
@@ -446,7 +446,7 @@ class IPAddr6 (_AddrBase):
     """
     Factory that creates an IPAddr6 from a large integer
     """
-    return bytes( (num >> i) & 0xff for i in range(120,-8,-8) )
+    return cls( bytes((num >> i) & 0xff for i in range(120,-8,-8) ), raw=True)
 
   def __init__ (self, addr = None, raw = False, network_order = False):
     """

--- a/pox/openflow/discovery.py
+++ b/pox/openflow/discovery.py
@@ -181,7 +181,7 @@ class LLDPSender (object):
     """
 
     chassis_id = pkt.chassis_id(subtype=pkt.chassis_id.SUB_LOCAL)
-    chassis_id.id = bytes('dpid:' + hex(int(dpid))[2:-1])
+    chassis_id.id = ('dpid:' + hex(int(dpid))[2:]).encode()
     # Maybe this should be a MAC.  But a MAC of what?  Local port, maybe?
 
     port_id = pkt.port_id(subtype=pkt.port_id.SUB_PORT, id=str(port_num))
@@ -189,7 +189,7 @@ class LLDPSender (object):
     ttl = pkt.ttl(ttl = ttl)
 
     sysdesc = pkt.system_description()
-    sysdesc.payload = bytes('dpid:' + hex(int(dpid))[2:-1])
+    sysdesc.payload = ('dpid:' + hex(int(dpid))[2:]).encode()
 
     discovery_packet = pkt.lldp()
     discovery_packet.tlvs.append(chassis_id)
@@ -385,7 +385,7 @@ class Discovery (EventMixin):
       for t in lldph.tlvs[3:]:
         if t.tlv_type == pkt.lldp.SYSTEM_DESC_TLV:
           # This is our favored way...
-          for line in t.payload.split('\n'):
+          for line in t.payload.decode().split('\n'):
             if line.startswith('dpid:'):
               try:
                 return int(line[5:], 16)
@@ -405,7 +405,7 @@ class Discovery (EventMixin):
     if originatorDPID == None:
       # We'll look in the CHASSIS ID
       if lldph.tlvs[0].subtype == pkt.chassis_id.SUB_LOCAL:
-        if lldph.tlvs[0].id.startswith('dpid:'):
+        if lldph.tlvs[0].id.startswith(b'dpid:'):
           # This is how NOX does it at the time of writing
           try:
             originatorDPID = int(lldph.tlvs[0].id[5:], 16)


### PR DESCRIPTION
Fix factory class function for IPAddr6 to return the instantiated class.

Tests output:
```
nosetests
..........................................SSS...............................................................................................................................................................................
----------------------------------------------------------------------
Ran 220 tests in 0.842s

OK (SKIP=3)
```

Signed-off-by: Loic Reyreaud <lre@open.ch>